### PR TITLE
Custom Markers as slot (#34)

### DIFF
--- a/src/Marker.svelte
+++ b/src/Marker.svelte
@@ -25,11 +25,16 @@
   export let popup = true
 
   let marker
+  let element
 
   $: marker && move(lng, lat)
 
   onMount(() => {
-    marker = new mapbox.Marker({ color, offset: markerOffset })
+    if(element.hasChildNodes()) {
+      marker = new mapbox.Marker({ element, offset: markerOffset })
+    } else {
+      marker = new mapbox.Marker({ color, offset: markerOffset })
+    }
 
     if (popup) {
       const popupEl = new mapbox.Popup({
@@ -51,3 +56,7 @@
     return marker
   }
 </script>
+
+<div bind:this={element}>
+<slot ></slot>
+</div>


### PR DESCRIPTION
* Custom Markers as slot

This adds the ability to user HTML inside the Marker which is used as marker:

```svelte
<Marker
    popup={false}
    lat={geo.lat}
    lng={geo.lng}
    >
    <a href={waypoint.slug}>
        <p>TEST</p>
    </a>
</Marker>
```

* Support html syntax for popup content 

modifies this PR https://github.com/beyonk-adventures/svelte-mapbox/pull/26 to use slots

* fix

* Revert "Support html syntax for popup content"